### PR TITLE
sitemap and meta tags for public faq questions

### DIFF
--- a/lib/actions/faq/helpdeskFaqSave.controller.php
+++ b/lib/actions/faq/helpdeskFaqSave.controller.php
@@ -65,6 +65,9 @@ class helpdeskFaqSaveController extends waJsonController
         $data['is_backend'] = waRequest::request('is_backend', 0, waRequest::TYPE_INT);
         $data['comment'] = waRequest::request('comment', null, waRequest::TYPE_STRING_TRIM);
         $data['url'] = waRequest::request('faq_url', '', waRequest::TYPE_STRING_TRIM);
+        $data['title'] = waRequest::post('title', '', waRequest::TYPE_STRING_TRIM);
+        $data['keywords'] = waRequest::post('keywords', '', waRequest::TYPE_STRING_TRIM);
+        $data['description'] = waRequest::post('description', '', waRequest::TYPE_STRING_TRIM);
         return $data;
     }
 }

--- a/lib/actions/frontend/helpdeskFrontendFaqCategoryQuestion.action.php
+++ b/lib/actions/frontend/helpdeskFrontendFaqCategoryQuestion.action.php
@@ -29,6 +29,14 @@ class helpdeskFrontendFaqCategoryQuestionAction extends helpdeskFrontendViewActi
 
         $this->setThemeTemplate('faq.category.question.html');
         $this->getResponse()->setTitle($faq['question']);
+        if (!empty($faq['title'])) {
+            $this->getResponse()->setTitle($faq['title']);
+        }
+        $meta = array('keywords', 'description');
+        foreach ($meta as $meta_field)
+            if (!empty($faq[$meta_field])) {
+                $this->getResponse()->setMeta($meta_field, $faq[$meta_field]);
+        }
         $this->view->assign('category', $category);
         $this->view->assign('faq', $faq);
 

--- a/lib/config/db.php
+++ b/lib/config/db.php
@@ -26,6 +26,10 @@ return array(
         'is_backend' => array('tinyint', 1, 'null' => 0, 'default' => '0'),
         'url' => array('varchar', 255),
         'comment' => array('text'),
+        'title' => array('varchar', 255, 'null' => 0),
+        'description' => array('varchar', 255, 'null' => 0),
+        'keywords' => array('varchar', 255, 'null' => 0),
+        'update_datetime' => array('datetime'),
         ':keys' => array(
             'PRIMARY' => 'id',
         ),

--- a/lib/config/helpdeskSitemapConfig.class.php
+++ b/lib/config/helpdeskSitemapConfig.class.php
@@ -1,0 +1,47 @@
+<?php
+
+class helpdeskSitemapConfig extends waSitemapConfig
+{
+    public function execute()
+    {
+        $routes = $this->getRoutes();
+
+        $fcm = new helpdeskFaqCategoryModel();
+        $page_model = new helpdeskPageModel();
+
+        foreach ($routes as $route) {
+            $this->routing->setRoute($route);
+            $u = $this->getUrlByRoute($route);
+            $domain = $this->routing->getDomain(null, true);
+            $route_url = $domain.'/'.$this->routing->getRoute('url');
+            $route_url = trim(rtrim($route_url, '*/'));
+
+            $categories = $fcm->getList('', array(
+                'is_public' => true,
+                'routes' => array($route_url)
+            ));
+            foreach ($categories as $c) {
+                $c_url = $u . 'faq/';
+                if (!empty($c['url'])) {
+                    $c_url .= $c['url'] . '/';
+                }
+                $fm = new helpdeskFaqModel();
+                $faq_list = $fm->getByFaqCategory($c['id'], true);
+                $lastmod = 0;
+                foreach ($faq_list as $row) {
+                    $faq_lastmod = strtotime(!empty($row['update_datetime']) ? $row['update_datetime'] : $row['create_datetime']);
+                    if ($faq_lastmod > $lastmod) {
+                        $lastmod = $faq_lastmod;
+                    }
+                    $this->addUrl($c_url.$row['url'].'/', $faq_lastmod, self::CHANGE_MONTHLY, 0.8);
+                }
+                if (!$lastmod) {
+                    $lastmod = date('Y-m-d H:i:s');
+                }
+                $this->addUrl($c_url, $lastmod, self::CHANGE_WEEKLY, 0.2);
+            }
+            // pages
+            $this->addPages($page_model, $route);
+        }
+    }
+}

--- a/lib/model/helpdeskFaq.model.php
+++ b/lib/model/helpdeskFaq.model.php
@@ -7,6 +7,7 @@ class helpdeskFaqModel extends waModel
     public function add($data)
     {
         $data['create_datetime'] = date('Y-m-d H:i:s');
+        $data['update_datetime'] = date('Y-m-d H:i:s');
         $data['contact_id'] = wa()->getUser()->getId();
 
         if (empty($data['faq_category_id'])) {
@@ -51,6 +52,7 @@ class helpdeskFaqModel extends waModel
         if (!$item) {
             return false;
         }
+        $data['update_datetime'] = date('Y-m-d H:i:s');
         $this->updateById($id, $data);
         $this->copyAnswerFiles($id);
         if ($item['faq_category_id'] != $data['faq_category_id']) {

--- a/lib/updates/1.2/1552280450.php
+++ b/lib/updates/1.2/1552280450.php
@@ -1,0 +1,18 @@
+<?php
+
+$m = new waModel();
+
+$columns = array('title', 'description', 'keywords');
+foreach ($columns as $column) {
+    try {
+        $m->query('SELECT '.$column.' FROM `helpdesk_faq` WHERE 0');
+    } catch (waDbException $e) {
+        $m->exec('ALTER TABLE `helpdesk_faq` ADD COLUMN `'.$column.'` VARCHAR(255) NOT NULL');
+    }
+}
+
+try {
+    $m->query('SELECT `update_datetime` FROM `helpdesk_faq` WHERE 0');
+} catch (waDbException $e) {
+    $m->exec('ALTER TABLE `helpdesk_faq` ADD COLUMN `update_datetime` DATETIME NULL DEFAULT NULL');
+}

--- a/templates/actions/faq/Faq.html
+++ b/templates/actions/faq/Faq.html
@@ -74,6 +74,19 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="field h-frontend-url {if !$faq.is_public}hidden{/if}">
+                            <div class="name">[s`<strong class="title">Title</strong>`] <span class="hint">&lt;title&gt;</span></div>
+                            <div class="value"><input type="text" name="title" value="" class="bold long"></div>
+                        </div>
+                        <div class="field h-frontend-url {if !$faq.is_public}hidden{/if}">
+                            <div class="name">[s`META Keywords`]</div>
+                            <div class="value"><input type="text" name="keywords" value=""></div>
+                        </div>
+                        <div class="field h-frontend-url {if !$faq.is_public}hidden{/if}">
+                            <div class="name">[s`META Description`]</div>
+                            <div class="value"><textarea name="description"></textarea></div>
+                        </div>
                     {/if}
 
                 </div>


### PR DESCRIPTION
По мотивам:
https://support.webasyst.ru/forum/30968/sitemap-dlya-prilozheniya-podderzhka-i-metategi-dlya-chavo-faq/

Реализована поддержка sitemap (страницы + публичные категории и вопросы-ответы).
Добавлена возможность указать title, description, keywords для публичных вопросов-ответов.

Добавлены новые колонки в таблицу `helpdesk_faq`:  
- update_datetime (для корректной даты lastmod в sitemap.xml)
- title
- keywords
- description